### PR TITLE
Limit geocode suggestions to street addresses only

### DIFF
--- a/lib/themes/hampshire/assets/javascripts/hampshire.address_autocomplete.js
+++ b/lib/themes/hampshire/assets/javascripts/hampshire.address_autocomplete.js
@@ -12,6 +12,10 @@
     }
   };
 
+  var boundsSW = new google.maps.LatLng(50.723101, -2.025858);
+  var boundsNE = new google.maps.LatLng(51.428016, -0.609995);
+  var autoCompleteBounds = new google.maps.LatLngBounds(boundsSW, boundsNE);
+
   $(function(){
     $('#location').autocomplete({
       html: true,
@@ -19,7 +23,8 @@
         service.getPlacePredictions({
           input: request.term,
           componentRestrictions: {country: 'gb'},
-          types: ['geocode']
+          types: ['geocode'],
+          bounds: autoCompleteBounds
         }, function(predictions, status){
           predictions = $.map(predictions, filterPrediction);
           response($.map(predictions, function(prediction){


### PR DESCRIPTION
Adds a filter to the suggestions from Google's placesAutocompleteService that
only allows "route" prediction types to be returned. There are a lot of
options: https://developers.google.com/places/documentation/supported_types
but that seemed like the only one that didn't allow things we don't want (like
whole towns) in the results.

Closes #73

<!---
@huboard:{"order":63.0859375,"milestone_order":91,"custom_state":""}
-->
