### PR TITLE
Print nicer page titles on the search page

### DIFF
--- a/lib/themes/hampshire/views/applications/search.html.haml
+++ b/lib/themes/hampshire/views/applications/search.html.haml
@@ -1,4 +1,9 @@
-= content_for :title, @description
+= content_for :page_title do
+  - if params[:location]
+    Search results for "#{params[:search]}" around #{params[:location]}
+  - else
+    Search results for "#{params[:search]}"
+
 
 = content_for :extra_javascript do
   -# This has to be present in either view and come before the other js that


### PR DESCRIPTION
Covers searching by location and not, but doesn't deal with authority searching
yet as I don't think this page actually gets used for that?

Closes #77

<!---
@huboard:{"order":64.25,"milestone_order":92,"custom_state":""}
-->
