### PR TITLE
Fix the FOUC on the map page whilst JS loads

### DIFF
--- a/lib/themes/hampshire/assets/stylesheets/hampshire/_results.scss
+++ b/lib/themes/hampshire/assets/stylesheets/hampshire/_results.scss
@@ -12,6 +12,7 @@ body.search-results {
   }
 
   #results {
+    min-height: 500px;
     position: relative; // So we can absolutely position sidebar
   }
 

--- a/lib/themes/hampshire/views/applications/search.html.haml
+++ b/lib/themes/hampshire/views/applications/search.html.haml
@@ -53,16 +53,20 @@
         See more statistics for
         = link_to 'Some Lovely Council', '#', :class => 'parent-council-link'
 
-    #list{:class => 'results-display'}
-      - if @applications
-        = paginated_section @applications, :previous_label => "« Newer", :next_label => "Older »" do
-          = render "applications", :applications => @applications
+    - if @display == "map"
+      %noscript
+        #list{:class => 'results-display'}
+          - if @applications
+            = paginated_section @applications, :previous_label => "« Newer", :next_label => "Older »" do
+              = render "applications", :applications => @applications
+    - else
+      #list{:class => 'results-display'}
+        - if @applications
+          = paginated_section @applications, :previous_label => "« Newer", :next_label => "Older »" do
+            = render "applications", :applications => @applications
 
   - if @display == "map"
     #map{:class => 'results-display'}
-      %p Sorry, there would be a map here, but you need to have javascript enabled to view it.
-
-    = render "search_debug"
 
   = content_for :extra_javascript do
     = render "js_marker_template"


### PR DESCRIPTION
@zarino what do you think of this? I've wrapped the list in a `noscript` and
added a min-height to `#results` so that the footer doesn't come up to meet
the header for a moment. I'm happy with the former (though haml makes the
template a bit repetitive) but wonder if you can think of a better way to do
the former? Might it break something on small screens?

Note again this is based off 80-hampshire-ui, hence PRed onto that and will
need to wait for that to be merged before it can be.

Closes #86

<!---
@huboard:{"order":18.0,"milestone_order":105,"custom_state":""}
-->
