### PR TITLE
Add hampshire theme assets to the precompile list

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -77,6 +77,12 @@ module PlanningalertsApp
     config.assets.paths << "#{Rails.root}/lib/themes/hampshire/assets/images"
     config.assets.paths << "#{Rails.root}/lib/themes/hampshire/assets/stylesheets"
 
+    hampshire_path = "/../lib/themes/hampshire/assets"
+    hampshire_files = Dir[File.dirname(__FILE__) + "#{hampshire_path}/javascripts/*"]
+
+    config.assets.precompile += hampshire_files.map{ |x| x.split("/").last }
+    config.assets.precompile << "application.scss"
+
     # Application configuration
     # These are things that are nice to have as configurations but unlikely really
     # in practise to change much


### PR DESCRIPTION
Appends all the javascript file names and all the .scss file names that start with a letter to `config.assets.precompile`

Closes #106 

<!---
@huboard:{"order":118.0,"milestone_order":126,"custom_state":""}
-->
