### PR TITLE
Bypass InfoWindow on mobile

### DIFF
--- a/lib/themes/hampshire/assets/javascripts/hampshire.search_map.js
+++ b/lib/themes/hampshire/assets/javascripts/hampshire.search_map.js
@@ -70,9 +70,14 @@
             map: map
           });
           google.maps.event.addListener(marker, 'click', function() {
-            var content = markerTemplate(application);
-            infoWindow.setContent(content);
-            infoWindow.open(map, marker);
+            var tooSmall = ($('#map').height() < 500) || ($('#map').width() <= 480);
+            if(tooSmall){
+              window.location.href = '/applications/' + application.id + '/' + application.authority.short_name_encoded + '/' + application.council_reference;
+            } else {
+              var content = markerTemplate(application);
+              infoWindow.setContent(content);
+              infoWindow.open(map, marker);
+            }
           });
           markers.push(marker);
         });


### PR DESCRIPTION
Clicks on map markers now go straight to application page on narrow or shallow screens.

Fixes #130.
