### PR TITLE
Index council_reference field

### DIFF
--- a/lib/themes/hampshire/model_patches.rb
+++ b/lib/themes/hampshire/model_patches.rb
@@ -6,6 +6,7 @@ Rails.configuration.to_prepare do
 
   Application.class_eval do
     define_index do
+      indexes council_reference
       indexes description
       indexes address
       indexes suburb


### PR DESCRIPTION
Adds an index on the council_reference field

Will require a rake ts:rebuild when deployed

Closes #177
