### PR TITLE
Zoom map to fit markers after loading. Fixes #139

### DIFF
--- a/lib/themes/hampshire/assets/javascripts/hampshire.search_map.js
+++ b/lib/themes/hampshire/assets/javascripts/hampshire.search_map.js
@@ -61,6 +61,10 @@
           maxWidth: 260 - 23 // Google Maps adds 23px on for close button
         });
 
+        // Define the bounds of the google map that we'll compute from the
+        // markers
+        var bounds = new google.maps.LatLngBounds();
+
         // Add markers to the map
         $.each(applications, function(index, applicationObject) {
           var application = applicationObject.application;
@@ -84,7 +88,12 @@
             }
           });
           markers.push(marker);
+          // Add the marker to the bounds
+          bounds.extend(marker.getPosition());
         });
+
+        // Zoom to the extent of the markers
+        map.fitBounds(bounds);
       }
     }
   });


### PR DESCRIPTION
I played with several options to solve the problem of not being able to see
everything within the default map zoom level. Reducing the radius did have
some effect, but it still wasn't optimal on small screens.

This however ensures that you always see everything that your search returned.
It has the downside that on mobile especially you don't see as detailed a view
of the map initially, but this is outweighed I think by the confusion of not
seeing any markers at all.

It has the advantage too of showing you a much _more_ detailed view on larger
screens, because it can zoom in as far as possible to show all the results.

I think we should perhaps tweak the minimum radius down a bit still, but
perhaps we can reduce it to 1 mile or 1/2 a mile instead. Otherwise people
won't see enough results for more specific queries. This is just a config
change that'll need to be made when this is deployed.

Closes #139

<!---
@huboard:{"order":178.5,"milestone_order":179,"custom_state":""}
-->
