### PR TITLE
Simpler way to configure Sphinx for multiple sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ tmp/sass-cache
 coverage
 log/searchd.development.pid
 config/database.yml
-config/development.sphinx.conf
+config/*.sphinx.conf
 config/general.yml
 config/test.yml
 db/sphinx/development/*
@@ -19,6 +19,7 @@ public/getinvolved.html
 public/index.html
 public/sitemap.xml
 public/sitemaps/sitemap*.xml.gz
+public/assets
 webrat.log
 .DS_Store
 planningalerts-app.sublime-workspace

--- a/lib/themes/hampshire/model_patches.rb
+++ b/lib/themes/hampshire/model_patches.rb
@@ -2,10 +2,18 @@ Rails.configuration.to_prepare do
   Application.instance_eval do
     scope :in_past_week, where("date_received > ?", 7.days.ago)
     scope :recent, where("date_received >= ?", 14.days.ago)
+
+    def search_index_name
+      prefix = ""
+      if defined?(Configuration::THEME_HAMPSHIRE_HOST)
+        prefix = Configuration::THEME_HAMPSHIRE_HOST.gsub(/[\.:]/, '')
+      end
+      "#{prefix}_application"
+    end
   end
 
   Application.class_eval do
-    define_index do
+    define_index(search_index_name) do
       indexes council_reference
       indexes description
       indexes address

--- a/script/post-deploy
+++ b/script/post-deploy
@@ -32,7 +32,10 @@ fi
 
 bundle exec rake db:migrate
 
-# restart Sphinx
+# create a Sphinx config file
+bundle exec rake ts:config
+
+# ensure Sphinx is running
 bundle exec rake ts:restart
 
 if [ "$RAILS_ENV" = production ]


### PR DESCRIPTION
I was looking at https://github.com/mysociety/planningalerts-app/pull/185
again so that I could deploy the live hampshire site and it seemed to me that
we could achieve the same result with a simpler method.

This takes the code to generate a custom search index name from the above PR,
but uses the `THEME_HAMPSHIRE_HOST` setting to generate a unique index name,
instead of needing a new config variable. I figured that would always be
unique anyway, so there was no need for a separate setting.

After that, I looked at getting the config file deployed and it looks to me
like we don't really need to do anything special, except make sure that the
config file is generated in the first place. So, I put an extra command in
`scripts/post-deploy` to do that as well as restarting Sphinx.

I'm not sure what I've missed over the old PR? It seems that any rake ts:xxx
commands will use the config file this deploys, which will connect to the
existing searchd instance, but use the details of the vhost's database and the
custom index names we create. There doesn't seem to be a need to hijack them
to setup the config ourselves? The only thing that PR gains is not restarting
searchd if the config hasn't changed, which is nice bit probably not a
game-changer at this point. In the future, I think we could do something in
the post-deploy directly to achieve the same thing.

Closes #181