### PR TITLE
Improve Vagrant script & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Please note - customisations which are specific to mySociety's Hampshire theme h
 
 **Step 1 - Seed authorities table**
  * Start the rails server - `rails s`
- * Create an admin user - TODO: Explain how to do this
+ * Create an admin user:
+   * Run the following in `rails console`:
+   * `User.create(email: 'admin@example.com', password: 'password')`
  * Go to the admin console - http://localhost:3000/admin
  * Create the authority Marrickville with the following data
    * FULL NAME	`Marrickville Council`

--- a/script/provision.sh
+++ b/script/provision.sh
@@ -18,10 +18,11 @@ sudo apt-get install tcl8.5 -y
 #install rvm
 # TODO: Needs Jones truncation armour, currently fails if used: http://drj11.wordpress.com/2014/03/19/piping-into-shell-may-be-harmful/
 
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 curl -sSL https://get.rvm.io | bash -s stable
 source .bash_profile
 
-rvm install rvm install 1.9.3-p547
+rvm install 1.9.3-p547
 
 cd /vagrant
 bundle install


### PR DESCRIPTION
A couple of small improvements to first-time setup:
- Fix RVM installation in the vagrant provisioning script
  - RVM releases need a public key to be imported so their signatures can be verified
  - Small typo on `rvm install` line
- Add instructions for adding a user for acccessing the admin
