### PR TITLE
Add some example searches to the front page

### DIFF
--- a/lib/themes/hampshire/assets/stylesheets/hampshire/_home.scss
+++ b/lib/themes/hampshire/assets/stylesheets/hampshire/_home.scss
@@ -214,4 +214,12 @@ body.initial-search {
       background-color: mix(#fff, $color-hampshire-red, 90%);
     }
   }
+
+  #suggested-searches {
+      margin-top: 2em;
+
+      a:link {
+          text-decoration: none;
+      }
+  }
 }

--- a/lib/themes/hampshire/views/applications/_initial_search_form.html.haml
+++ b/lib/themes/hampshire/views/applications/_initial_search_form.html.haml
@@ -18,3 +18,12 @@
       %button.button.button-rounded.button-large.button-action{:type => "submit"}
         %i.fa.fa-search
         Search
+    %div#suggested-searches
+      %p
+        Need some inspiration? How about...
+      %div
+        #{link_to "All applications in Fordingbridge", search_applications_path(search: "anything", location: "Provost Street, Fordingbridge")},
+        #{link_to "County council matters in Winchester", search_applications_path(search: "county council matters", location: "Upper High Street, Winchester")},
+      %div
+        #{link_to "Extensions in Aldershot", search_applications_path(search: "extensions", location: "High Street, Aldershot")}, or
+        #{link_to "Refused applications for extensions near SP6 1AP", search_applications_path(search: "extensions", location: "SP6 1AP", status: "refused")}?


### PR DESCRIPTION
Looks like:

![screen shot 2015-08-26 at 12 09 51](https://cloud.githubusercontent.com/assets/4776/9492005/9aa21986-4beb-11e5-9257-3f303af6048d.png)

Fixes #197 
